### PR TITLE
Revert "Added open in new tab for email share option"

### DIFF
--- a/src/components/SocialShareButton.tsx
+++ b/src/components/SocialShareButton.tsx
@@ -24,14 +24,9 @@ interface CustomProps<LinkOptions> {
   forwardedRef?: Ref<HTMLButtonElement>;
   networkName: string;
   networkLink: NetworkLink<LinkOptions>;
-  onClick?: (
-    event: React.MouseEvent<HTMLButtonElement>,
-    link: string,
-    newTab?: boolean,
-  ) => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>, link: string) => void;
   openShareDialogOnClick?: boolean;
   opts: LinkOptions;
-  newTab?: boolean;
   /**
    * URL of the shared page
    */
@@ -95,7 +90,6 @@ export default class SocialShareButton<LinkOptions> extends Component<
       url,
       openShareDialogOnClick,
       opts,
-      newTab,
     } = this.props;
 
     const link = networkLink(url, opts);
@@ -119,7 +113,7 @@ export default class SocialShareButton<LinkOptions> extends Component<
     }
 
     if (onClick) {
-      onClick(event, link, newTab);
+      onClick(event, link);
     }
   };
 

--- a/src/components/buttons/EmailShareButton.ts
+++ b/src/components/buttons/EmailShareButton.ts
@@ -5,7 +5,6 @@ type Options = {
   body?: string;
   separator?: string;
   subject?: string;
-  newTab?: boolean;
 };
 
 function emailLink(url: string, { subject, body, separator }: Options) {
@@ -24,13 +23,12 @@ const EmailShareButton = createShareButton<Options>(
   (props) => ({
     subject: props.subject,
     body: props.body,
-    newTab: props.newTab || false,
     separator: props.separator || ' ',
   }),
   {
     openShareDialogOnClick: false,
-    onClick: (_, link: string, newTab?: boolean) => {
-      window.open(link, newTab ? '_blank' : '_self');
+    onClick: (_, link: string) => {
+      window.location.href = link;
     },
   },
 );


### PR DESCRIPTION
Using `window.open` for mailto link does not open browser, it open native mail client.