### PR TITLE
Loosen peer deps constraints (>= React 17, >= react-scripts 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,8 +92,8 @@
     }
   ],
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0",
     "react-scripts": "^4.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,6 @@
   "peerDependencies": {
     "react": ">=17.0.0",
     "react-dom": ">=17.0.0",
-    "react-scripts": "^4.0.3"
+    "react-scripts": ">=4.0.0"
   }
 }


### PR DESCRIPTION
Since npm v7, `npm install` will fail when it encounters conflicting peerDependencies by default. This PR enables `next-share` to be installed on projects running React 18 and/or react scripts 5.