### PR TITLE
Use only api.whatsapp.com

### DIFF
--- a/src/components/buttons/WhatsappShareButton.ts
+++ b/src/components/buttons/WhatsappShareButton.ts
@@ -1,18 +1,12 @@
 import transformObjectToParams from '../../utils';
 import createShareButton from '../../hocs/createShareButton';
 
-function isMobileOrTablet() {
-  return /(android|iphone|ipad|mobile)/i.test(navigator.userAgent);
-}
-
 function whatsappLink(
   url: string,
   { title, separator }: { title?: string; separator?: string },
 ) {
   return (
-    'https://' +
-    (isMobileOrTablet() ? 'api' : 'web') +
-    '.whatsapp.com/send' +
+    'https://api.whatsapp.com/send' +
     transformObjectToParams({
       text: title ? title + separator + url : url,
     })


### PR DESCRIPTION
WhatsApp's new API does not require us to differentiate between web.whatsapp and api.whatsapp. 
api.whatsapp can handle WhatsApp mobile, WhatsApp Web and even WhatsApp Desktop.

I've tested this on my side and it works great!

Works on: 
- WhatsApp Mobile
- WhatsApp Web (in browser)
- WhatsApp Desktop