### PR TITLE
chore: add sideEffects false to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,6 @@
   },
   "dependencies": {
     "jsonp": "^0.2.1"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
This allows webpack to potentially better optimise the package, by telling it that the package does not cause side effects by being imported. See https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free