### PR TITLE
Use the resetButtonStyle prop to reset or not the styles passed

### DIFF
--- a/src/components/SocialShareButton.tsx
+++ b/src/components/SocialShareButton.tsx
@@ -118,18 +118,27 @@ export default class SocialShareButton<LinkOptions> extends Component<
   };
 
   render() {
-    const { children, forwardedRef, networkName, style, ...rest } = this.props;
+    const {
+      children,
+      forwardedRef,
+      networkName,
+      style,
+      resetButtonStyle,
+      ...rest
+    } = this.props;
 
-    const newStyle = {
-      backgroundColor: 'transparent',
-      border: 'none',
-      padding: 0,
-      font: 'inherit',
-      color: 'inherit',
-      cursor: 'pointer',
-      outline: 'none',
-      ...style,
-    };
+    const newStyle = resetButtonStyle
+      ? {
+          backgroundColor: 'transparent',
+          border: 'none',
+          padding: 0,
+          font: 'inherit',
+          color: 'inherit',
+          cursor: 'pointer',
+          outline: 'none',
+          ...style,
+        }
+      : style;
 
     return (
       <button


### PR DESCRIPTION
Hello ! 

First of all thanks for the lib :)
For my use case I have to use specific styling and currently the prop `resetButtonStyle` has no effect and always override possible custom css class styling. 
So I've enabled resetButtonStyle usage. 

Tell me if everything is ok for you or if I need to make other changes ! 

Thanx

