### PR TITLE
fix: broken Reddit share link

### DIFF
--- a/src/components/buttons/RedditShareButton.ts
+++ b/src/components/buttons/RedditShareButton.ts
@@ -3,8 +3,9 @@ import createShareButton from '../../hocs/createShareButton';
 
 function redditLink(url: string, { title }: { title?: string }) {
   return (
-    'https://www.reddit.com/submit' +
+    'https://new.reddit.com/submit' +
     transformObjectToParams({
+      type: 'LINK',
       url,
       title,
     })


### PR DESCRIPTION
As of at least two months ago, Reddit share links no longer work.

See: https://www.reddit.com/r/webdev/comments/1coavp2/comment/l3kvppo/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

Switching to `new.reddit.com` now works, and a `type` parameter is now required.

### Fails

https://www.reddit.com/submit?title=test&url=https%3A%2F%2Fwww.google.com

- default `type` is `TEXT`, but should be `LINK`
- post body is not populated

### Passes

https://new.reddit.com/submit?type=LINK&title=test&url=https%3A%2F%2Fwww.google.com

- `type` is set to `LINK` explicitly
- `url` is successfully populated